### PR TITLE
DTO 들에 Serializable 인터페이스 제거

### DIFF
--- a/src/main/java/com/fc/projectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/fc/projectboard/dto/response/ArticleCommentResponse.java
@@ -1,9 +1,8 @@
 package com.fc.projectboard.dto.response; // 패키지 선언, DTO의 응답 클래스들을 모아둔 패키지 경로
 
-import com.fc.projectboard.dto.ArticleCommentDto; // ArticleCommentDto 클래스를 사용하기 위해 임포트
+import com.fc.projectboard.dto.ArticleCommentDto;
 
-import java.io.Serializable; // Serializable 인터페이스를 사용하기 위해 임포트
-import java.time.LocalDateTime; // 날짜와 시간을 다루는 LocalDateTime 클래스를 임포트
+import java.time.LocalDateTime;
 
 // ArticleCommentResponse 는 응답 데이터 구조를 정의하는 레코드 클래스
 public record ArticleCommentResponse(
@@ -12,7 +11,7 @@ public record ArticleCommentResponse(
         LocalDateTime createdAt, // 댓글이 생성된 시간
         String email, // 댓글 작성자의 이메일
         String nickname // 댓글 작성자의 닉네임
-) implements Serializable { // Serializable 인터페이스를 구현하여 객체가 직렬화 가능하도록 함
+) {
 
     // 정적 팩토리 메서드, 객체 생성과 초기화를 동시에 처리하여 새로운 ArticleCommentResponse 객체를 반환
     public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {

--- a/src/main/java/com/fc/projectboard/dto/response/ArticleResponse.java
+++ b/src/main/java/com/fc/projectboard/dto/response/ArticleResponse.java
@@ -1,9 +1,8 @@
 package com.fc.projectboard.dto.response; // 패키지 선언, 이 클래스가 위치할 패키지 경로 지정
 
-import com.fc.projectboard.dto.ArticleDto; // ArticleDto 클래스를 사용하기 위해 해당 클래스를 임포트
+import com.fc.projectboard.dto.ArticleDto;
 
-import java.io.Serializable; // 객체가 직렬화 가능하도록 하기 위해 Serializable 인터페이스를 임포트
-import java.time.LocalDateTime; // 날짜와 시간을 다루기 위해 LocalDateTime 클래스를 임포트
+import java.time.LocalDateTime;
 
 // ArticleResponse는 레코드 클래스로, 응답 데이터 구조를 간단하게 정의
 public record ArticleResponse(
@@ -14,7 +13,7 @@ public record ArticleResponse(
         LocalDateTime createdAt, // 게시글 생성 시간
         String email, // 게시글 작성자의 이메일
         String nickname // 게시글 작성자의 닉네임
-) implements Serializable { // Serializable 인터페이스 구현으로 객체 직렬화 가능
+) {
 
     // 정적 팩토리 메서드, 모든 필드 값을 입력받아 새로운 ArticleResponse 객체를 생성하여 반환
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {

--- a/src/main/java/com/fc/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/fc/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -2,7 +2,6 @@ package com.fc.projectboard.dto.response;
 
 import com.fc.projectboard.dto.ArticleWithCommentsDto;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -17,7 +16,7 @@ public record ArticleWithCommentsResponse(
         String email, // 게시글 작성자의 이메일 주소
         String nickname, // 게시글 작성자의 닉네임
         Set<ArticleCommentResponse> articleCommentsResponses // 게시글에 달린 댓글 목록, ArticleCommentResponse 객체의 집합
-) implements Serializable { // Serializable 인터페이스를 구현하여 객체의 직렬화가 가능하도록 함
+) {
 
     // 정적 팩토리 메서드, 필요한 모든 정보를 받아 ArticleWithCommentResponse 객체를 생성하고 반환
     public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {


### PR DESCRIPTION
JPA Buddy 를 이용해 작성한 DTO들인데,
자동으로 `implements Serializable` 이 들어가버림
우리 프로젝트는 직렬화로 Jackson을 사용하므로
필요하지 않고, 의도하여 넣은 코드도 아님
그러므로 삭제