### PR TITLE
헤더에 해시태그 메뉴 추가하기

### DIFF
--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -9,7 +9,8 @@
         <div class="container">
             <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
                 <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                    <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+                    <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                    <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtags</a></li>
                 </ul>
 
                 <div class="text-end">

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>


### PR DESCRIPTION
#38 에서 해시태그 기능을 구현했는데, 쉽게 접근할 수 있도록 배려를 하지 않았다.
이를 헤더에 추가하여 쉽게 해시태그 검색 페이지 존재를 알고, 들어갈 수 있게 한다.