### PR TITLE
[리팩토링] 해시태그에 대문자를 사용하여 등록 시 오류 수정

### DIFF
--- a/src/main/java/com/fc/projectboard/service/ArticleService.java
+++ b/src/main/java/com/fc/projectboard/service/ArticleService.java
@@ -137,7 +137,7 @@ public class ArticleService {
                 .collect(Collectors.toUnmodifiableSet());
 
         hashtagNamesInContent.forEach(newHashtagName -> {
-            if (!existingHashtagNames.contains(newHashtagName)) {
+            if (!existingHashtagNames.contains(newHashtagName.toLowerCase())) {
                 hashtags.add(Hashtag.of(newHashtagName));
             }
         });

--- a/src/main/java/com/fc/projectboard/service/ArticleService.java
+++ b/src/main/java/com/fc/projectboard/service/ArticleService.java
@@ -137,7 +137,7 @@ public class ArticleService {
                 .collect(Collectors.toUnmodifiableSet());
 
         hashtagNamesInContent.forEach(newHashtagName -> {
-            if (!existingHashtagNames.contains(newHashtagName.toLowerCase())) {
+            if (!existingHashtagNames.contains(newHashtagName)) {
                 hashtags.add(Hashtag.of(newHashtagName));
             }
         });

--- a/src/main/java/com/fc/projectboard/service/HashtagService.java
+++ b/src/main/java/com/fc/projectboard/service/HashtagService.java
@@ -33,7 +33,7 @@ public class HashtagService {
         Set<String> result = new HashSet<>();
 
         while (matcher.find()) {
-            result.add(matcher.group().replace("#", ""));
+            result.add(matcher.group().replace("#", "").toLowerCase());
         }
 
         return Set.copyOf(result);

--- a/src/test/java/com/fc/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/fc/projectboard/service/ArticleServiceTest.java
@@ -236,6 +236,29 @@ class ArticleServiceTest {
                 .containsExactlyInAnyOrderElementsOf(expectedHashtagNames);
     }
 
+    @DisplayName("게시글 정보와 해시태그를 기록할 때, 해시태그의 대소문자를 무시한다.")
+    @Test
+    void givenArticleInfo_whenSavingArticleAndItsHashtags_thenIgnoreCaseOfHashtags() {
+        // Given
+        Set<String> expectedHashtagNames = Set.of("java", "Spring");
+        Set<Hashtag> expectedExistingHashtags = new HashSet<>(List.of(createHashtag(1L, "java"), createHashtag(2L, "spring")));
+        ArgumentCaptor<Article> articleCaptor = ArgumentCaptor.forClass(Article.class);
+
+        given(userAccountRepository.getReferenceById(any())).willReturn(createUserAccount());
+        given(hashtagService.parseHashtagNames(any())).willReturn(expectedHashtagNames);
+        given(hashtagService.findHashtagsByNames(expectedHashtagNames)).willReturn(expectedExistingHashtags);
+        given(articleRepository.save(any(Article.class))).willReturn(createArticle());
+
+        // When
+        sut.saveArticle(createArticleDto());
+
+        // Then
+        then(articleRepository).should().save(articleCaptor.capture());
+        assertThat(articleCaptor.getValue().getHashtags())
+                .extracting("hashtagName")
+                .containsExactlyInAnyOrder("java", "spring");
+    }
+    
     @DisplayName("게시글의 수정 정보를 입력하면, 게시글을 수정한다.")
     @Test
     void givenModifiedArticleInfo_whenUpdatingArticle_thenUpdatesArticle() {

--- a/src/test/java/com/fc/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/fc/projectboard/service/ArticleServiceTest.java
@@ -236,29 +236,6 @@ class ArticleServiceTest {
                 .containsExactlyInAnyOrderElementsOf(expectedHashtagNames);
     }
 
-    @DisplayName("게시글 정보와 해시태그를 기록할 때, 해시태그의 대소문자를 무시한다.")
-    @Test
-    void givenArticleInfo_whenSavingArticleAndItsHashtags_thenIgnoreCaseOfHashtags() {
-        // Given
-        Set<String> expectedHashtagNames = Set.of("java", "Spring");
-        Set<Hashtag> expectedExistingHashtags = new HashSet<>(List.of(createHashtag(1L, "java"), createHashtag(2L, "spring")));
-        ArgumentCaptor<Article> articleCaptor = ArgumentCaptor.forClass(Article.class);
-
-        given(userAccountRepository.getReferenceById(any())).willReturn(createUserAccount());
-        given(hashtagService.parseHashtagNames(any())).willReturn(expectedHashtagNames);
-        given(hashtagService.findHashtagsByNames(expectedHashtagNames)).willReturn(expectedExistingHashtags);
-        given(articleRepository.save(any(Article.class))).willReturn(createArticle());
-
-        // When
-        sut.saveArticle(createArticleDto());
-
-        // Then
-        then(articleRepository).should().save(articleCaptor.capture());
-        assertThat(articleCaptor.getValue().getHashtags())
-                .extracting("hashtagName")
-                .containsExactlyInAnyOrder("java", "spring");
-    }
-    
     @DisplayName("게시글의 수정 정보를 입력하면, 게시글을 수정한다.")
     @Test
     void givenModifiedArticleInfo_whenUpdatingArticle_thenUpdatesArticle() {

--- a/src/test/java/com/fc/projectboard/service/HashtagServiceTest.java
+++ b/src/test/java/com/fc/projectboard/service/HashtagServiceTest.java
@@ -33,10 +33,10 @@ class HashtagServiceTest {
     @Mock
     private HashtagRepository hashtagRepository;
 
-    @DisplayName("본문을 파싱하면, 해시태그 이름들을 중복 없이 반환한다.")
+    @DisplayName("본문을 파싱하면, 해시태그 이름들을 중복 없이 대소문자를 무시하고 반환한다.")
     @MethodSource
     @ParameterizedTest(name = "[{index}] \"{0}\" => {1}")
-    void givenContent_whenParsing_thenReturnsUniqueHashtagNames(String input, Set<String> expected) {
+    void givenContent_whenParsing_thenReturnsUniqueHashtagNamesIgnoringCase(String input, Set<String> expected) {
         // Given
 
         // When
@@ -47,7 +47,7 @@ class HashtagServiceTest {
         then(hashtagRepository).shouldHaveNoInteractions();
     }
 
-    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagNames() {
+    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagNamesIgnoringCase() {
         return Stream.of(
                 arguments(null, Set.of()),
                 arguments("", Set.of()),
@@ -59,6 +59,7 @@ class HashtagServiceTest {
                 arguments("java#", Set.of()),
                 arguments("ja#va", Set.of("va")),
                 arguments("#java", Set.of("java")),
+                arguments("#Java", Set.of("java")),
                 arguments("#java_spring", Set.of("java_spring")),
                 arguments("#java-spring", Set.of("java")),
                 arguments("#_java_spring", Set.of("_java_spring")),
@@ -66,6 +67,7 @@ class HashtagServiceTest {
                 arguments("#_java_spring__", Set.of("_java_spring__")),
                 arguments("#java#spring", Set.of("java", "spring")),
                 arguments("#java #spring", Set.of("java", "spring")),
+                arguments("#java #Spring", Set.of("java", "spring")),
                 arguments("#java  #spring", Set.of("java", "spring")),
                 arguments("#java   #spring", Set.of("java", "spring")),
                 arguments("#java     #spring", Set.of("java", "spring")),
@@ -81,6 +83,7 @@ class HashtagServiceTest {
                 arguments("   #java,? #spring  ...  #부트 ", Set.of("java", "spring", "부트")),
                 arguments("#java#java#spring#부트", Set.of("java", "spring", "부트")),
                 arguments("#java#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#JAVA#Java#sPRINg#부트", Set.of("java", "spring", "부트")),
                 arguments("#java#spring#java#부트#java", Set.of("java", "spring", "부트")),
                 arguments("#java#스프링 아주 긴 글~~~~~~~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
                 arguments("아주 긴 글~~~~~~~~~~~~~~~~~~~~~#java#스프링", Set.of("java", "스프링")),


### PR DESCRIPTION
이 pr은 게시글을 저장할 때, 함께 저장하는 해시태그의 대소문자를 가리지 않도록 기능을 수정합니다.

This closes #110 